### PR TITLE
Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Please note that if the slug field is localized in a specific model, so needs to
 
 The plugin allows you to define a specific path per model, and per locale, where an item should be previewed. 
 
-For instance, your model is called 'posts' and you have a post called 'hello world'. By default, the previewlink would be `SITE_URL/hello-world`. But let's say you have your front set-up so that under the English version of your site the post is accessbile under `SITE_URL/articles/hello-world`. To fix the Gatsby preview-link, make a new (hidden) text-field under your model called `frontendPath` and fill the default value with the correct path for each locale (so `articles` for English). 
+For instance, your model is called 'posts' and you have a post called 'hello world'. By default, the previewlink would be `SITE_URL/hello-world`. But let's say you have your front set-up so that under the English version of your site the post is accessbile under `SITE_URL/articles/hello-world`. To fix the Gatsby preview-link, make a new (hidden) text-field under your model with the id `frontend_path` and fill the default value with the correct path for each locale (so `articles` for English). 
 
 ### Locale prefix
 

--- a/README.md
+++ b/README.md
@@ -24,3 +24,14 @@ Once you've configured the plugin, you will be able to see it as a sidebar widge
 
 Please note that if the slug field is localized in a specific model, so needs to be the JSON field on which the plugin gets installed.
 
+### Localized Frontend path
+
+The plugin allows you to define a specific path per model, and per locale, where an item should be previewed. 
+
+For instance, your model is called 'posts' and you have a post called 'hello world'. By default, the previewlink would be `SITE_URL/hello-world`. But let's say you have your front set-up so that under the English version of your site the post is accessbile under `SITE_URL/articles/hello-world`. To fix the Gatsby preview-link, make a new (hidden) text-field under your model called `frontendPath` and fill the default value with the correct path for each locale (so `articles` for English). 
+
+### Locale prefix
+
+Use the option "useLocalePath" to give all Gatsby preview links a path-prefix for the current locale. So using the example above, when this option is set to true, the preview-link would become `SITE_URL/en/articles/hello-world`.
+
+Use the option "skipDefaultLocalePath" to disable this option for the default locale.

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
           "type": "boolean",
           "required": false,
           "default": false,
-          "hint": "Works in combination with 'Use locale path'. When set, it wil not generate a locale-path (e.g. '/en/') for the default local (e.g. first locale in evironment setting."
+          "hint": "Works in combination with 'Use locale path'. When set, it wil not generate a locale-path (e.g. '/en/') for the default locale (e.g. first locale in evironment setting)."
         },
         {
           "id": "instanceUrl",

--- a/package.json
+++ b/package.json
@@ -54,12 +54,12 @@
           "hint": "inserts locale-path (e.g. '/en/') into all urls"
         },
         {
-          "id": "skipLocalePath",
-          "label": "Skip localep-ath for this locale",
-          "type": "string",
+          "id": "skipDefaultLocalePath",
+          "label": "Skip locale-path for the default locale",
+          "type": "boolean",
           "required": false,
           "default": false,
-          "hint": "Works in combination with 'Use locale path'. When set, it wil not generate a locale-path (e.g. '/en/') for the chosen locale"
+          "hint": "Works in combination with 'Use locale path'. When set, it wil not generate a locale-path (e.g. '/en/') for the default local (e.g. first locale in evironment setting."
         },
         {
           "id": "instanceUrl",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,14 @@
           "hint": "Shows debug messages in console"
         },
         {
+          "id": "useLocalePath",
+          "label": "Use locale path",
+          "type": "boolean",
+          "required": false,
+          "default": false,
+          "hint": "inserts locale-path (e.g. '/en/') into all urls"
+        },
+        {
           "id": "instanceUrl",
           "label": "Gatsby Preview instance url",
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "main": "index.js",
   "scripts": {
     "start": "concurrently \"yarn dev\" \"yarn localtunnel\"",
-    "localtunnel": "lt -s datocms-plugin-gatsby-cloud --port 5001",
-    "dev": "NODE_ENV=development webpack-dev-server --port 5001",
+    "localtunnel": "lt -s datocms-plugin-gatsby-cloud --port 5000",
+    "dev": "NODE_ENV=development webpack-dev-server --port 5000",
     "dist": "NODE_ENV=production webpack --progress",
     "prepublishOnly": "rimraf lib dist && mkdir dist && npm run dist",
     "addToProject": "yo datocms-plugin:add-to-project",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "main": "index.js",
   "scripts": {
     "start": "concurrently \"yarn dev\" \"yarn localtunnel\"",
-    "localtunnel": "lt -s datocms-plugin-gatsby-cloud --port 5000",
-    "dev": "NODE_ENV=development webpack-dev-server --port 5000",
+    "localtunnel": "lt -s datocms-plugin-gatsby-cloud --port 5001",
+    "dev": "NODE_ENV=development webpack-dev-server --port 5001",
     "dist": "NODE_ENV=production webpack --progress",
     "prepublishOnly": "rimraf lib dist && mkdir dist && npm run dist",
     "addToProject": "yo datocms-plugin:add-to-project",
@@ -47,11 +47,19 @@
         },
         {
           "id": "useLocalePath",
-          "label": "Use locale path",
+          "label": "Use locale-path",
           "type": "boolean",
           "required": false,
           "default": false,
           "hint": "inserts locale-path (e.g. '/en/') into all urls"
+        },
+        {
+          "id": "skipLocalePath",
+          "label": "Skip localep-ath for this locale",
+          "type": "string",
+          "required": false,
+          "default": false,
+          "hint": "Works in combination with 'Use locale path'. When set, it wil not generate a locale-path (e.g. '/en/') for the chosen locale"
         },
         {
           "id": "instanceUrl",

--- a/src/Main.jsx
+++ b/src/Main.jsx
@@ -19,7 +19,7 @@ export default class Main extends Component {
     super(props);
     this.state = {
       contentSlug: '',
-      initalValue: '',
+      initialValue: '',
       slugField: '',
     };
     this.slugChange = this.slugChange.bind(this);
@@ -82,7 +82,7 @@ export default class Main extends Component {
 
     this.setState({
       slugField,
-      initalValue: urlParts.join('/'),
+      initialValue: urlParts.join('/'),
     });
 
     this.unsubscribe = plugin.addFieldChangeListener(fieldPath, this.slugChange);
@@ -109,13 +109,13 @@ export default class Main extends Component {
         global: { instanceUrl, authToken },
       },
     } = plugin;
-    const { initalValue, contentSlug } = this.state;
+    const { initialValue, contentSlug } = this.state;
 
     return (
       <div className="container">
         <h1>Gatsby Cloud</h1>
         <ExtensionUI
-          contentSlug={contentSlug || initalValue}
+          contentSlug={contentSlug || initialValue}
           previewUrl={instanceUrl}
           authToken={authToken}
         />

--- a/src/Main.jsx
+++ b/src/Main.jsx
@@ -47,23 +47,23 @@ export default class Main extends Component {
       .map(link => fields[link.id])
       .find(f => f.attributes.field_type === 'slug');
 
-    const frontendpathField = itemType.relationships.fields.data
+    const frontendPathField = itemType.relationships.fields.data
       .map(link => fields[link.id])
-      .find(f => f.attributes.api_key === 'frontendpath');
+      .find(f => f.attributes.api_key === 'frontend_path');
 
-    if (frontendpathField && frontendpathField.attributes.localized) {
-      const frontendpathValue = frontendpathField.attributes.localized
-        ? `${frontendpathField.attributes.api_key}.${locale}`
-        : frontendpathField.attributes.api_key;
+    if (frontendPathField && frontendPathField.attributes.localized) {
+      const frontendPathValue = frontendPathField.attributes.localized
+        ? `${frontendPathField.attributes.api_key}.${locale}`
+        : frontendPathField.attributes.api_key;
 
-      const pathPrefixValue = plugin.getFieldValue(frontendpathValue);
+      const pathPrefixValue = plugin.getFieldValue(frontendPathValue);
       if (pathPrefixValue) urlParts.push(pathPrefixValue);
     }
 
-    if (frontendpathField
-      && (slugField.attributes.localized && !frontendpathField.attributes.localized)) {
+    if (frontendPathField
+      && (slugField.attributes.localized && !frontendPathField.attributes.localized)) {
       console.error(`Since the "${slugField.attributes.api_key}" slug field is localized, 
-      so needs to be the "${frontendpathField.attributes.api_key}" field!`);
+      so needs to be the "${frontendPathField.attributes.api_key}" field!`);
 
       return;
     }

--- a/src/Main.jsx
+++ b/src/Main.jsx
@@ -47,16 +47,26 @@ export default class Main extends Component {
       .map(link => fields[link.id])
       .find(f => f.attributes.field_type === 'slug');
 
-    const modelslugField = itemType.relationships.fields.data
+    const frontendpathField = itemType.relationships.fields.data
       .map(link => fields[link.id])
-      .find(f => f.attributes.api_key === 'modelslug');
+      .find(f => f.attributes.api_key === 'frontendpath');
 
-    const modelslugValue = modelslugField.attributes.localized
-      ? `${modelslugField.attributes.api_key}.${locale}`
-      : modelslugField.attributes.api_key;
+    if (frontendpathField && frontendpathField.attributes.localized) {
+      const frontendpathValue = frontendpathField.attributes.localized
+        ? `${frontendpathField.attributes.api_key}.${locale}`
+        : frontendpathField.attributes.api_key;
 
-    const pathPrefixValue = plugin.getFieldValue(modelslugValue);
-    if (pathPrefixValue) urlParts.push(pathPrefixValue);
+      const pathPrefixValue = plugin.getFieldValue(frontendpathValue);
+      if (pathPrefixValue) urlParts.push(pathPrefixValue);
+    }
+
+    if (frontendpathField
+      && (slugField.attributes.localized && !frontendpathField.attributes.localized)) {
+      console.error(`Since the "${slugField.attributes.api_key}" slug field is localized, 
+      so needs to be the "${frontendpathField.attributes.api_key}" field!`);
+
+      return;
+    }
 
     if (!slugField) {
       if (developmentMode) {

--- a/src/Main.jsx
+++ b/src/Main.jsx
@@ -35,11 +35,13 @@ export default class Main extends Component {
       locale,
       field,
       parameters: {
-        global: { developmentMode, useLocalePath, skipLocalePath },
+        global: { developmentMode, useLocalePath, skipDefaultLocalePath },
       },
     } = plugin;
 
-    if (useLocalePath && skipLocalePath !== locale) urlParts.push(locale);
+    if (useLocalePath && !(skipDefaultLocalePath && plugin.site.attributes.locales[0] === locale)) {
+      urlParts.push(locale);
+    }
 
     const slugField = itemType.relationships.fields.data
       .map(link => fields[link.id])

--- a/src/Main.jsx
+++ b/src/Main.jsx
@@ -35,11 +35,11 @@ export default class Main extends Component {
       locale,
       field,
       parameters: {
-        global: { developmentMode, useLocalePath },
+        global: { developmentMode, useLocalePath, skipLocalePath },
       },
     } = plugin;
 
-    if (useLocalePath) urlParts.push(locale);
+    if (useLocalePath && skipLocalePath !== locale) urlParts.push(locale);
 
     const slugField = itemType.relationships.fields.data
       .map(link => fields[link.id])


### PR DESCRIPTION
Adds option to also localize the slug of a model, instead of only the slug of the item. And optionally adds a locale prefix to the preview url.

